### PR TITLE
Expand PATH variable in service file

### DIFF
--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -29,6 +29,7 @@ describe 'homeassistant' do
         it { is_expected.to contain_python__pyvenv('/srv/homeassistant') }
         it { is_expected.to contain_systemd__unit_file('homeassistant.service').with_content(%r{^User=homeassistant}) }
         it { is_expected.to contain_systemd__unit_file('homeassistant.service').with_content(%r{^ExecStart=/srv/homeassistant/bin/hass -c "/etc/homeassistant"}) }
+        it { is_expected.to contain_systemd__unit_file('homeassistant.service').with_content(%r{^Environment=PATH="/srv/homeassistant/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"}) }
         it { is_expected.to contain_service('homeassistant').with_enable(true) }
         it { is_expected.to contain_concat('configuration.yaml').with_path('/etc/homeassistant/configuration.yaml') }
         it { is_expected.to contain_concat__fragment('homeassistant').with_target('configuration.yaml') }

--- a/templates/homeassistant.service.erb
+++ b/templates/homeassistant.service.erb
@@ -7,7 +7,7 @@ After=network.target
 Type=simple
 User=homeassistant
 Environment=VIRTUAL_ENV="<%= @home %>"
-Environment=PATH="$VIRTUAL_ENV/bin:$PATH"
+Environment=PATH="<%= @home %>/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 ExecStart=<%= @home %>/bin/hass -c "<%= @confdir %>"
 
 [Install]


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Systemd doesn't do variable expansion in its unit definition.
From the `systemd.exec` man page:
>Variable expansion is not performed inside the strings, however, specifier expansion is possible.

Effectively this breaks finding of binaries if Home Assistant is set up with this module. (In my case demonstrated by the `wake-on-lan` component not being able to find `ping`.)

So I propose to replace '$VIRTUAL_ENV' with '<%= @home %>'.
And '$PATH' with the PATH variable from /etc/profile (in this PR it is from Raspbian).

#### This Pull Request (PR) fixes the following issues
I did not make an issue for this PR. There is no open issue describing the same.
