### PR TITLE
Add version parameter to homeassistant class

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,6 +9,7 @@ class homeassistant (
   Stdlib::Absolutepath $home   = '/srv/homeassistant',
   Stdlib::Absolutepath $confdir = '/etc/homeassistant',
   Boolean $known_devices_replace = false,
+  String $version = 'present',
 ) {
   class { 'homeassistant::install': }
   -> class { 'homeassistant::config': }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -28,11 +28,10 @@ class homeassistant::install (
   }
 
   class { 'python':
-    ensure     => present,
-    version    => 'system',
-    pip        => 'present',
-    virtualenv => 'present',
-    dev        => 'present',
+    ensure  => present,
+    version => 'python3',
+    pip     => 'present',
+    dev     => 'present',
   }
 
   python::pyvenv { $home:

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -1,6 +1,7 @@
 class homeassistant::install (
   $home    = $homeassistant::home,
   $confdir = $homeassistant::confdir,
+  $version = $homeassistant::version,
 ) inherits homeassistant {
   group { 'homeassistant':
     ensure => present,
@@ -41,7 +42,7 @@ class homeassistant::install (
   }
 
   python::pip { 'homeassistant':
-    ensure     => present,
+    ensure     => $version,
     virtualenv => $home,
     owner      => 'homeassistant',
     group      => 'homeassistant',


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
Add version specification to the `homeassistant` class. This way you can pin the version from your Puppet code, or have Puppet update your Homeassistant installation.

#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
